### PR TITLE
docs: update issue template to use word implementation plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/component.md
+++ b/.github/ISSUE_TEMPLATE/component.md
@@ -1,13 +1,13 @@
 ---
 name: component
 about: Implement a new basecn-ui component
-title: "[component]: [Component Name]"
+title: "[component]:"
 labels: feat-component
 assignees: p-iknow
 
 ---
 
-## Component to Implement
+## Compnents
 
 **basecn-ui Component Name:** 
 
@@ -15,15 +15,12 @@ assignees: p-iknow
 
 ** base-ui Component(s) Reference:** 
 
-## Summery 
-**Requirement:** 
-
-**Implementation:** 
+## Context (optional)
 
 **Context**
 *If the MUI Base UI interface differs from Radix UI or requires intentional API changes*
 
-## Testing 
-- [ ] Storybook stories created and tested
+## Should be Tested
+- [ ] xx
 
-## Reference
+## Reference (optional)

--- a/.github/ISSUE_TEMPLATE/config.md
+++ b/.github/ISSUE_TEMPLATE/config.md
@@ -1,26 +1,20 @@
 ---
 name: config
 about: Add or update project configuration, dependencies, or tooling
-title: "[confg]: [Description]"
+title: "[confg]:"
 labels: feat-config
 assignees: p-iknow
 
 ---
 
-## Summary
-
-**What needs to be configured:**
-
 ## Requirement
 
-## Implementation
+## Implementation plan(optional)
 
 **Dependencies (if applicable):**
 
-**Configuration changes:**
 
-
-## Testing
+## Should be tested
 
 - [ ] Configuration tested locally
 - [ ] CI/CD pipeline verified (if applicable)

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -1,19 +1,15 @@
 ---
 name: doc
 about: Add or update project documentation
-title: "[doc]: [Description]"
+title: "[doc]:"
 labels: doc
 assignees: p-iknow
 
 ---
 
-## Summary
-
-**What documentation needs to be created/updated:**
-
 ## Requirement
 
-## Implementation
+## Implementation Plan (optional)
 
 **Documentation type:**
 
@@ -21,10 +17,10 @@ assignees: p-iknow
 
 **Files to be modified:**
 
-## Testing
+## Should be tested
 - [ ] Documentation reviewed for accuracy
 - [ ] Examples tested and working
 - [ ] Consistency with existing documentation maintained
 - [ ] References and links properly connected
 
-## Reference
+## Reference (optionla)

--- a/.github/ISSUE_TEMPLATE/util.md
+++ b/.github/ISSUE_TEMPLATE/util.md
@@ -1,23 +1,19 @@
 ---
 name: util
 about: Add or update utility functions, helpers, or shared module
-title: "[util]: [Description]"
+title: "[util]:"
 labels: feat-util
 assignees: p-iknow
 
 ---
 
-## Summary
-
-**What utility needs to be created/updated:**
-
 ## Requirement
 
-## Implementation
+## Implementation Plan (optional)
 
-## Testing
+## Should be tested
 
 - [ ] Unit tests written and passing
 - [ ] Edge cases covered
 
-## Reference
+## Reference (optional)


### PR DESCRIPTION
## Summary

closes #6 

**What documentation needs to be created/updated:**

Update all GitHub issue templates to use "Implementation Plan" instead of "Implementation" for better clarity and consistency.

## Requirement

The current "Implementation" section name is ambiguous and could be confused with actual implementation work. "Implementation Plan" better represents that this section is for planning the approach rather than documenting completed implementation.

## Implementation

**Documentation type:**
GitHub Issue Templates update

**Content outline:**
- Update all existing issue templates
- Change "Implementation" section headers to "Implementation Plan"
- Maintain all existing content and structure

**Files to be modified:**
- `.github/ISSUE_TEMPLATE/component.md`
- `.github/ISSUE_TEMPLATE/documentation.md`
- `.github/ISSUE_TEMPLATE/config.md`
- `.github/ISSUE_TEMPLATE/utils.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`

## Testing

- [x] Documentation should be reviewed for accuracy
- [x] Examples should be tested and working
- [x] Consistency with existing documentation should be maintained
- [n/a] References and links should be properly connected

## Reference